### PR TITLE
VSF2-181 - Add default wishlist on login

### DIFF
--- a/features/shop/account/creating_account.feature
+++ b/features/shop/account/creating_account.feature
@@ -27,6 +27,7 @@ Feature: Creating base customer account
         And This response should contain 'shopUserToken.user.username' equal to "adam.monroe@mail.com"
         And This response should contain 'shopUserToken.token'
         And This response should contain 'shopUserToken.refreshToken'
+        And The user "adam.monroe@mail.com" has default wishlist "My Wishlist"
 
     @graphql
     Scenario: Creating account and doesnt log in when channel denies unverified users login

--- a/spec/EventListener/AttachDefaultWishlistEventListenerSpec.php
+++ b/spec/EventListener/AttachDefaultWishlistEventListenerSpec.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+*/
+
+declare(strict_types=1);
+
+namespace spec\BitBag\SyliusVueStorefront2Plugin\EventListener;
+
+use BitBag\SyliusVueStorefront2Plugin\Model\ShopUserTokenInterface;
+use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
+use BitBag\SyliusWishlistPlugin\Factory\WishlistFactoryInterface;
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
+use BitBag\SyliusWishlistPlugin\Resolver\WishlistCookieTokenResolverInterface;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class AttachDefaultWishlistEventListenerSpec extends ObjectBehavior
+{
+    function let(
+        WishlistRepositoryInterface $wishlistRepository,
+        WishlistFactoryInterface $wishlistFactory,
+        WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver,
+        ChannelContextInterface $channelContext
+    ): void {
+        $this->beConstructedWith(
+            $wishlistRepository,
+            $wishlistFactory,
+            $wishlistCookieTokenResolver,
+            $channelContext
+        );
+    }
+
+    function it_early_returns_when_no_user_is_set_to_a_token(
+        ShopUserTokenInterface $shopUserToken
+    ): void {
+        $shopUserToken->getUser()->willReturn(null);
+
+        $event = new GenericEvent($shopUserToken->getWrappedObject(), []);
+        $this->addDefaultWishlist($event);
+    }
+
+    function it_early_returns_when_user_already_has_a_wishlist(
+        ShopUserTokenInterface $shopUserToken,
+        ShopUserInterface $shopUser,
+        ChannelContextInterface $channelContext,
+        ChannelInterface $currentChannel,
+        WishlistRepositoryInterface $wishlistRepository,
+        WishlistInterface $wishlist
+    ): void {
+        $shopUserToken->getUser()->willReturn($shopUser);
+        $channelContext->getChannel()->willReturn($currentChannel);
+
+        $wishlistRepository->findOneByShopUserAndChannel($shopUser, $currentChannel)
+            ->willReturn($wishlist);
+
+        $event = new GenericEvent($shopUserToken->getWrappedObject(), []);
+        $this->addDefaultWishlist($event);
+    }
+
+    function it_adds_default_wishlist(
+        ShopUserTokenInterface $shopUserToken,
+        ShopUserInterface $shopUser,
+        ChannelContextInterface $channelContext,
+        ChannelInterface $currentChannel,
+        WishlistRepositoryInterface $wishlistRepository,
+        WishlistFactoryInterface $wishlistFactory,
+        WishlistInterface $wishlist,
+        WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver,
+    ): void {
+        $shopUserToken->getUser()->willReturn($shopUser);
+        $channelContext->getChannel()->willReturn($currentChannel);
+
+        $wishlistRepository->findOneByShopUserAndChannel($shopUser, $currentChannel)
+            ->willReturn(null);
+
+        $wishlistFactory->createForUserAndChannel($shopUser, $currentChannel)
+            ->willReturn($wishlist);
+
+        $wishlistToken = 'wishlist-token';
+        $wishlistCookieTokenResolver->resolve()
+            ->willReturn($wishlistToken);
+
+        $wishlist->setName('My Wishlist')
+            ->shouldBeCalledOnce();
+
+        $wishlist->setToken($wishlistToken)
+            ->shouldBeCalledOnce();
+
+        $wishlistRepository->add($wishlist)
+            ->shouldBeCalledOnce();
+
+        $event = new GenericEvent($shopUserToken->getWrappedObject(), []);
+        $this->addDefaultWishlist($event);
+    }
+}

--- a/src/EventListener/AttachDefaultWishlistEventListener.php
+++ b/src/EventListener/AttachDefaultWishlistEventListener.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+*/
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusVueStorefront2Plugin\EventListener;
+
+use BitBag\SyliusVueStorefront2Plugin\Model\ShopUserTokenInterface;
+use BitBag\SyliusWishlistPlugin\Factory\WishlistFactoryInterface;
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepository;
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
+use BitBag\SyliusWishlistPlugin\Resolver\WishlistCookieTokenResolverInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class AttachDefaultWishlistEventListener
+{
+    private const DEFAULT_WISHLIST_NAME = 'My Wishlist';
+
+    public function __construct(
+        private WishlistRepositoryInterface $wishlistRepository,
+        private WishlistFactoryInterface $wishlistFactory,
+        private WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver,
+        private ChannelContextInterface $channelContext
+    ) {
+
+    }
+
+    public function addDefaultWishlist(GenericEvent $event): void
+    {
+        /** @var ShopUserTokenInterface $shopUserToken */
+        $shopUserToken = $event->getSubject();
+        $shopUser = $shopUserToken->getUser();
+
+        if ($shopUser === null) {
+            return;
+        }
+
+        /** @var ChannelInterface $currentChannel */
+        $currentChannel = $this->channelContext->getChannel();
+
+        $wishlist = $this->wishlistRepository->findOneByShopUserAndChannel($shopUser, $currentChannel);
+        if ($wishlist !== null) {
+            return;
+        }
+
+        $wishlist = $this->wishlistFactory->createForUserAndChannel($shopUser, $currentChannel);
+        $wishlist->setName(self::DEFAULT_WISHLIST_NAME);
+
+        $wishlistToken = $this->wishlistCookieTokenResolver->resolve();
+        $wishlist->setToken($wishlistToken);
+
+        $this->wishlistRepository->add($wishlist);
+    }
+}

--- a/src/Resources/services/behat/contexts.xml
+++ b/src/Resources/services/behat/contexts.xml
@@ -25,6 +25,8 @@
                  class="Tests\BitBag\SyliusVueStorefront2Plugin\Behat\Context\Shop\LoginContext">
             <argument type="service" id="bitbag.sylius_vue_storefront2_plugin.behat.client.graphql_client" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.repository.shop_user" />
+            <argument type="service" id="bitbag_sylius_wishlist_plugin.repository.wishlist" />
         </service>
 
         <service id="bitbag.sylius_vue_storefront2_plugin.context.registration"

--- a/src/Resources/services/event_listeners.xml
+++ b/src/Resources/services/event_listeners.xml
@@ -21,5 +21,17 @@
             <tag name="kernel.event_listener" event="sylius.product.post_create" method="resolveThumbnails" priority="-300" />
             <tag name="kernel.event_listener" event="sylius.product.post_update" method="resolveThumbnails" priority="-300" />
         </service>
+
+        <service
+            id="app.event_listener.attach_default_wishlist_listener"
+            class="BitBag\SyliusVueStorefront2Plugin\EventListener\AttachDefaultWishlistEventListener"
+        >
+            <argument type="service" id="bitbag_sylius_wishlist_plugin.repository.wishlist" />
+            <argument type="service" id="bitbag_sylius_wishlist_plugin.factory.wishlist" />
+            <argument type="service" id="bitbag_sylius_wishlist_plugin.resolver.wishlist_cookie_token_resolver" />
+            <argument type="service" id="sylius.context.channel" />
+
+            <tag name="kernel.event_listener" event="bitbag.sylius_vue_storefront2.mutation_resolver.login.complete" method="addDefaultWishlist" />
+        </service>
     </services>
 </container>

--- a/tests/Behat/Context/Shop/LoginContext.php
+++ b/tests/Behat/Context/Shop/LoginContext.php
@@ -1,13 +1,24 @@
 <?php
 
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+*/
+
 declare(strict_types=1);
 
 namespace Tests\BitBag\SyliusVueStorefront2Plugin\Behat\Context\Shop;
 
 use Behat\Behat\Context\Context;
+use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Tests\BitBag\SyliusVueStorefront2Plugin\Behat\Client\GraphqlClient;
 use Tests\BitBag\SyliusVueStorefront2Plugin\Behat\Client\GraphqlClientInterface;
+use Webmozart\Assert\Assert;
 
 final class LoginContext implements Context
 {
@@ -15,12 +26,20 @@ final class LoginContext implements Context
 
     private SharedStorageInterface $sharedStorage;
 
+    private RepositoryInterface $shopUserRepository;
+
+    private WishlistRepositoryInterface $wishlistRepository;
+
     public function __construct(
         GraphqlClientInterface $client,
         SharedStorageInterface $sharedStorage,
+        RepositoryInterface $shopUserRepository,
+        WishlistRepositoryInterface $wishlistRepository,
     ) {
         $this->client = $client;
         $this->sharedStorage = $sharedStorage;
+        $this->shopUserRepository = $shopUserRepository;
+        $this->wishlistRepository = $wishlistRepository;
     }
 
     /**
@@ -43,5 +62,31 @@ final class LoginContext implements Context
             'password' => $password,
         ]);
         $this->sharedStorage->set(GraphqlClient::GRAPHQL_OPERATION, $operation);
+    }
+
+    /**
+     * @Then The user :userEmail has default wishlist :wishlistName
+     */
+    public function theUserHasDefaultWishlist(
+        string $userEmail,
+        string $wishlistName
+    ): void {
+        $shopUser = $this->shopUserRepository->findOneBy([
+            'username' => $userEmail,
+        ]);
+        Assert::notNull($shopUser);
+
+        $channel = $this->sharedStorage->get('channel');
+        Assert::notNull($channel);
+
+        $wishlists = $this->wishlistRepository->findBy([
+            'shopUser' => $shopUser,
+            'channel' => $channel,
+        ]);
+        Assert::count($wishlists, 1);
+
+        /** @var WishlistInterface $wishlist */
+        $wishlist = $wishlists[0];
+        Assert::eq($wishlist->getName(), $wishlistName);
     }
 }


### PR DESCRIPTION
When users log in the very first time, they have no wishlist attached to the account. On VSF side it breaks adding product to wishlist byy displaying blank list. The current PR checks whether user has at least one wishlist. If there is none, the default one is created.